### PR TITLE
Set version information via cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,6 @@ target_link_libraries(jpsvis PUBLIC
         Qt5::Core
         ${VTK_LIBRARIES}
         glm::glm
-        git-info
         tinyxml
 )
 
@@ -141,7 +140,7 @@ target_include_directories(tinyxml PUBLIC
 target_include_directories(jpsvis PUBLIC "${CMAKE_SOURCE_DIR}/src" "${CMAKE_SOURCE_DIR}/forms" ${CMAKE_BINARY_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 set(SRCS
     forms/jpsvis.rc
-    src/BuildInfo.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/src/BuildInfo.cpp
     src/Frame.cpp
     src/IO/OutputHandler.cpp
     src/InteractorStyle.cpp
@@ -224,10 +223,7 @@ set(RCS
 )
 
 target_sources(jpsvis PRIVATE ${SRCS} ${HDR} ${UIS} ${HDR} ${RCS})
-
-target_compile_definitions(jpsvis PUBLIC
-    JPSVIS_VERSION="${PROJECT_VERSION}"
-)
+configure_file(src/BuildInfo.cpp.in ${CMAKE_BINARY_DIR}/src/BuildInfo.cpp @ONLY)
 
 ################################################################################
 # Packaging with CPack

--- a/cmake/helper_functions.cmake
+++ b/cmake/helper_functions.cmake
@@ -35,7 +35,7 @@ endmacro()
 # - GIT_TAG: current tag
 # - GIT_COMMIT_SUBJECT: subject of the latest commit
 # - GIT_BRANCH: current branch
-function(get_git_info)
+macro(get_git_info)
     find_package(Git QUIET)
 
     # Returns 0 if the given directory is a git repo
@@ -88,13 +88,4 @@ function(get_git_info)
         set(GIT_BRANCH "UNKNOWN")
         set(GIT_TAG "UNKNOWN")
     endif()
-
-    add_library(git-info INTERFACE)
-    target_compile_definitions(git-info INTERFACE
-            GIT_COMMIT_HASH="${GIT_SHA1}"
-            GIT_COMMIT_DATE="${GIT_DATE}"
-            GIT_TAG="${GIT_TAG}"
-            GIT_COMMIT_SUBJECT="${GIT_COMMIT_SUBJECT}"
-            GIT_BRANCH="${GIT_BRANCH}"
-            )
-endfunction()
+endmacro()

--- a/src/BuildInfo.cpp
+++ b/src/BuildInfo.cpp
@@ -1,8 +1,0 @@
-#include "BuildInfo.h"
-
-std::string ver_string(int a, int b, int c)
-{
-    std::ostringstream ss;
-    ss << a << '.' << b << '.' << c;
-    return ss.str();
-}

--- a/src/BuildInfo.cpp.in
+++ b/src/BuildInfo.cpp.in
@@ -1,0 +1,10 @@
+#include "BuildInfo.h"
+
+const std::string JPSVIS_VERSION = "@CMAKE_PROJECT_VERSION@";
+
+const std::string GIT_COMMIT_HASH = "@GIT_SHA1@";
+const std::string GIT_COMMIT_DATE = "@GIT_DATE@";
+const std::string GIT_BRANCH = "@GIT_BRANCH@";
+
+const std::string COMPILER = "@CMAKE_CXX_COMPILER_ID@";
+const std::string COMPILER_VERSION = "@CMAKE_CXX_COMPILER_VERSION@";

--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -3,30 +3,11 @@
 #include <sstream>
 #include <string>
 
-std::string ver_string(int a, int b, int c);
+extern const std::string JPSVIS_VERSION;
 
-const std::string true_cxx =
-#ifdef __clang__
-    "clang++";
-#elif defined(__GNUC__)
-    "g++";
-#elif defined(__MINGW32__)
-    "MinGW";
-#elif defined(_MSC_VER)
-    "Visual Studio";
-#else
-    "Compiler not identified";
-#endif
+extern const std::string GIT_COMMIT_HASH;
+extern const std::string GIT_COMMIT_DATE;
+extern const std::string GIT_BRANCH;
 
-const std::string true_cxx_ver =
-#ifdef __clang__
-    ver_string(__clang_major__, __clang_minor__, __clang_patchlevel__);
-#elif defined(__GNUC__)
-    ver_string(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
-#elif defined(__MINGW32__)
-    ver_string(__MINGW32__, __MINGW32_MAJOR_VERSION, __MINGW32_MINOR_VERSION);
-#elif defined(_MSC_VER)
-    ver_string(_MSC_VER, _MSC_FULL_VER, _MSC_BUILD);
-#else
-    "";
-#endif
+extern const std::string COMPILER;
+extern const std::string COMPILER_VERSION;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -32,6 +32,7 @@
 #include "MainWindow.h"
 
 #include "ApplicationState.h"
+#include "BuildInfo.h"
 #include "Frame.h"
 #include "Log.h"
 #include "Parsing.h"
@@ -300,10 +301,10 @@ void MainWindow::slotHelpAbout()
                         "%3</p>"
                         "<p  style=\"line-height:0.4\" style=\"color:Gray;\"><i>Branch</i> "
                         "%4</p><hr>")
-            .arg(JPSVIS_VERSION)
-            .arg(GIT_COMMIT_HASH)
-            .arg(GIT_COMMIT_DATE)
-            .arg(GIT_BRANCH);
+            .arg(JPSVIS_VERSION.c_str())
+            .arg(GIT_COMMIT_HASH.c_str())
+            .arg(GIT_COMMIT_DATE.c_str())
+            .arg(GIT_BRANCH.c_str());
 
     QString text =
         QMessageBox::tr("<p style=\"color:Gray;\"><small><i> &copy; 2009-2021  Ulrich Kemloh "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,11 +63,11 @@ int main(int argc, char * argv[])
 {
     Log::Info("\n----\nJuPedSim - JPSvis\n");
     Log::Info("Current date   : %s %s", __DATE__, __TIME__);
-    Log::Info("Version        : %s", JPSVIS_VERSION);
-    Log::Info("Compiler       : %s (%s)", true_cxx.c_str(), true_cxx_ver.c_str());
-    Log::Info("Commit hash    : %s", GIT_COMMIT_HASH);
-    Log::Info("Commit date    : %s", GIT_COMMIT_DATE);
-    Log::Info("Branch         : %s\n----\n", GIT_BRANCH);
+    Log::Info("Version        : %s", JPSVIS_VERSION.c_str());
+    Log::Info("Compiler       : %s (%s)", COMPILER.c_str(), COMPILER_VERSION.c_str());
+    Log::Info("Commit hash    : %s", GIT_COMMIT_HASH.c_str());
+    Log::Info("Commit date    : %s", GIT_COMMIT_DATE.c_str());
+    Log::Info("Branch         : %s\n----\n", GIT_BRANCH.c_str());
 
     QSurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat());
 


### PR DESCRIPTION
This allows to state the type of the variable explicitly instead of using macros.
The tags with `@name@` will be substituted with the explicit value from the cmake call. 

Small disadvantage, the compiler name will be set according to this list: https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
For us it means:
g++ → GNU
clang++  → Clang/AppleClang
Visual Studio → MSVC
