### PR TITLE
Fix hard coded path in benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ For the visualization module (`jpsvis`) the following libraries are required.
 |------|---------|
 | Qt   | >= 5.12 |
 | VTK  | >= 9.0  |
+| GLM  | >=0.9.9 |
+
+### Optional Requirements [-DWITH\_BENCHMARKS]
+
+If you would like to create micro benchmarks during development you will
+additionally need google-benchmark.
+
+On MacOS this is available as `google-benchmark`, on Windows via vcpkg as
+`benchmark` and on Linux it is recommended to compile from source. See:
+<https://github.com/google/benchmark>
 
 ### Install requirements for Mac OS X (with Homebrew)
 
@@ -83,6 +93,5 @@ For additional build options please see "Build Options" section in
 
 ## Contributing
 
-If you conttribute code you need to be aware that all code needs to be formated
+If you contribute code you need to be aware that all code needs to be formatted
 with clang-format-13. This is enforced by the CI.
-

--- a/benchmarks/parsing.cpp
+++ b/benchmarks/parsing.cpp
@@ -3,14 +3,22 @@
 #include "TrajectoryData.h"
 
 #include <benchmark/benchmark.h>
-
+#include <filesystem>
+/// A note about the benchmarks here:
+/// Right now we do not intend to execute thses in any automated enivronment
+/// Consider them as a local developemnt tool if you want to fine tune the performance of specifc
+/// functions.
 static void BM_ParseTxtFormat(benchmark::State & state)
 {
-    // Perform setup here
+    // Note: The path below will only work if you call the benchmarks from the source folder,
+    // i.e. from `jpsvis`  call: `./<path-to-build>/bin/benchmarks`
+    // Most likely you will want to replace this path with a path to a much larger file anyways that
+    // is not part of the repository, i.e. any trajectory upwards of 500 Mb.
+    const auto path = QString::fromStdString(
+        std::filesystem::current_path() / "samples/02_stairs/stairs_trajectories.txt");
     for(auto _ : state) {
         TrajectoryData data;
-        Parsing::ParseTxtFormat("/Users/kkratz/Downloads/results/bottleneck_traj.txt", &data);
+        Parsing::ParseTxtFormat(path, &data);
     }
 }
-// Register the function as a benchmark
 BENCHMARK(BM_ParseTxtFormat);


### PR DESCRIPTION
Benchmakrs have be run from the SOURCE folder to ensure that the
referenced files are found, e.g. you need to call:

    './<path-to-build-folder>/bin/benchmarks'
But in most cases you will want to modify the benchmark anyways because
the sample files are much to small anyways and you will probably want to
point to nay local file for benchmarking.

Be aware that the benchmarks are not run automatically because we
neither want nor can track any regression at this time.