### PR TITLE
adds missing optional include

### DIFF
--- a/src/CLI.h
+++ b/src/CLI.h
@@ -5,7 +5,7 @@
 #include <QCommandLineParser>
 #include <QStringList>
 #include <filesystem>
-
+#include <optional>
 
 enum class CLI {
     CommandLineOk,


### PR DESCRIPTION
In CLI.h the include for optional was missing. 