### PR TITLE
Converter of Petrack trajectories to jpsvis

### DIFF
--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -1,0 +1,180 @@
+import sys
+from os.path import exists
+import argparse
+import numpy as np
+import xml.etree.ElementTree as ET
+
+parser = argparse.ArgumentParser(
+    description='''Modify trajectory-files to be
+    visualized with jpsvis.
+    Trajectories are converted from cm to m.
+    Moreover, new columns are added (A, B, ANGLE, COLOR)
+    '''
+)
+parser.add_argument("-f", "--file", required=True, type=str,
+                    help='Petrack trajectory file')
+parser.add_argument("--cm", dest='convert', action='store_false',
+                    help='keep trajectories in cm')
+parser.set_defaults(convert=True)
+args = parser.parse_args()
+
+
+def extract_info(F) -> (str, int):
+    """
+    extract first 3 lines from experiment file.
+    Then append a description, a geometry and finally the
+    jpscore header.
+    return fps as well
+    """
+    header = "description: trajectories converted by {}\n".format(sys.argv[0])
+    fps = 16
+    for line in f:
+        header += line.split("#")[-1].lstrip().split("fps")[0]
+        if "framerate" in line:
+            header += "\ngeometry: geometry.xml\n"
+            fps = line.split("fps")[0].split()[-1]
+            break
+
+    header += "ID\tFR\tX\tY\tZ\tA\tB\tANGLE\tCOLOR"
+    try:
+        fps = int(fps)
+    except ValueError:
+        sys.exit("can not extract fps")
+
+    return (header, fps)
+
+
+def speed(data_now, data_future, df, fps) -> np.array:
+    #pdb.set_trace()
+    
+    Pos2 = data_future[:, 2:4]
+    Pos = data_now[:, 2:4]
+    
+    Delta_square = np.square(Pos2 - Pos)
+    
+    s = np.sqrt(Delta_square[:, 0] + Delta_square[:, 1])
+    
+    Speed = s/df*fps
+    return Speed
+
+
+def write_geometry(data, cm=1):
+    '''
+    Creates a bounding box around the trajectories
+    Output: geometry.xml
+    '''
+    Delta = 5  # some more space to better contain the trajectories
+    xmin = (np.min(data[2, :]) - Delta)/cm
+    xmax = (np.max(data[2, :]) + Delta)/cm
+    ymin = (np.min(data[3, :]) - Delta)/cm
+    ymax = (np.max(data[3, :]) + Delta)/cm
+    data = ET.Element('geometry')
+    data.set('version', '0.8')
+    data.set('caption', 'experiment')
+    data.set('unit', 'm')  # jpsvis does not support another unit!
+    rooms = ET.SubElement(data, 'rooms')
+    room = ET.SubElement(rooms, 'room')
+    room.set('id', '0')
+    room.set('caption', 'room')
+    subroom = ET.SubElement(room, 'subroom')
+    subroom.set('id', '0')
+    subroom.set('caption', 'subroom')
+    subroom.set('class', 'subroom')
+    subroom.set('A_x', '0')
+    subroom.set('B_y', '0')
+    subroom.set('C_z', '0')
+    # poly1
+    polygon = ET.SubElement(subroom, 'polygon')
+    polygon.set('caption', 'wall')
+    polygon.set('type', 'internal')
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmin)
+    vertex.set('py', '%.2f' % ymin)
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmax)
+    vertex.set('py', '%.2f' % ymin)
+    # poly2
+    polygon = ET.SubElement(subroom, 'polygon')
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmax)
+    vertex.set('py', '%.2f' % ymin)
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmax)
+    vertex.set('py', '%.2f' % ymax)
+    # poly3
+    polygon = ET.SubElement(subroom, 'polygon')
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmax)
+    vertex.set('py', '%.2f' % ymax)
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmin)
+    vertex.set('py', '%.2f' % ymax)
+    # poly4
+    polygon = ET.SubElement(subroom, 'polygon')
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmin)
+    vertex.set('py', '%.2f' % ymax)
+    vertex = ET.SubElement(polygon, 'vertex')
+    vertex.set('px', '%.2f' % xmin)
+    vertex.set('py', '%.2f' % ymin)
+    b_xml = ET.tostring(data, encoding='utf8', method='xml')
+    with open("geometry.xml", "wb") as f:
+        f.write(b_xml)
+
+
+def data_at_frame(data, frame) -> np.array:
+    return data[data[:, 1] == frame]
+
+
+if __name__ == '__main__':
+    File = args.file
+    if not exists(File):
+        sys.exit("file {} does not exist!".format(File))
+
+    cm = 100 if args.convert else 1
+
+    with open(File) as f:
+        header, fps = extract_info(f)
+        print("------")
+        print("file: {}".format(File))
+        print(header)
+        print("fps: {}".format(fps))
+        print("------")
+        data = np.loadtxt(File)
+        rows, cols = data.shape
+        A = 30 * np.ones((rows, 1))
+        B = 30 * np.ones((rows, 1))
+        ANGLE = np.zeros((rows, 1))
+        # COLOR = set_color(data)
+        COLOR = 100 * np.ones((rows, 1))
+        data = np.hstack((data, A, B, ANGLE, COLOR))
+        write_geometry(data, cm)
+        shape = data.shape
+        result = np.empty(shape[1])
+        cm2m = np.ones(shape[1])
+        cm2m[2:-2] *= cm  # exclude id, fr, angle and color from conversion
+        frames = np.unique(data[:, 1]).astype(int)
+        df = 10
+        v0 = 1.5
+        
+        for frame in frames:
+            #print(frame, np.max(frames))
+            data_fr = data_at_frame(data, frame)/cm2m
+            data_fr2 = data_at_frame(data, frame+df)/cm2m
+            #s = speed(data_fr, data_fr2, df, fps)
+            #Color = s/v0*255            
+            #data_fr[:, -1] = Color
+            result = np.vstack((result, data_fr))
+
+        filename = "jps_" + File
+        np.savetxt(filename, result[1:, :],
+                   fmt=["%d", "%d",  # id frame
+                        "%1.2f", "%1.2f", "%1.2f",  # x, y, z
+                        "%1.2f", "%1.2f",  # A, B
+                        "%1.2f",  # Angle
+                        "%d"],  # Color
+                   header=header,
+                   comments='#',
+                   delimiter='\t')
+
+        print("-> ", filename)

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -92,10 +92,10 @@ def write_geometry(data, cm=100):
     :returns: geometry file names geometry.xml
     """
     Delta = 100  # 1 m around to better contain the trajectories
-    xmin = (np.min(data[2, :]) - Delta)/cm
-    xmax = (np.max(data[2, :]) + Delta)/cm
-    ymin = (np.min(data[3, :]) - Delta)/cm
-    ymax = (np.max(data[3, :]) + Delta)/cm
+    xmin = (np.min(data[:, 2]) - Delta)/cm
+    xmax = (np.max(data[:, 2]) + Delta)/cm
+    ymin = (np.min(data[:, 3]) - Delta)/cm
+    ymax = (np.max(data[:, 3]) + Delta)/cm
     data = ET.Element('geometry')
     data.set('version', '0.8')
     data.set('caption', 'experiment')

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -4,6 +4,7 @@ import argparse
 from typing import Tuple
 import xml.etree.ElementTree as ET
 import numpy as np
+from pandas import read_csv
 
 parser = argparse.ArgumentParser(
     description='''Modify trajectory-files to be
@@ -273,7 +274,10 @@ def main():
         unit = 100 if unit_s == "cm" else 1
         v0 = 1.5 * unit  # max. speed (assumed) [unit/s]
         write_debug_msg(File, fps, df, unit_s)
-        data = np.loadtxt(File)
+        data = read_csv(File,
+                        sep=r"\s+",
+                        dtype=np.float64,
+                        comment="#").values
         data = extend_data(data, unit)
         geometry_file = File.parent.joinpath("geometry.xml")
         write_geometry(data, unit, geometry_file)

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -124,10 +124,10 @@ def write_geometry(data, Unit, geo_file):
     """
     Delta = 100 if Unit == "cm" else 1
     # 1 m around to better contain the trajectories
-    xmin = (np.min(data[:, 2]) - Delta)
-    xmax = (np.max(data[:, 2]) + Delta)
-    ymin = (np.min(data[:, 3]) - Delta)
-    ymax = (np.max(data[:, 3]) + Delta)
+    xmin = np.min(data[:, 2]) - Delta
+    xmax = np.max(data[:, 2]) + Delta
+    ymin = np.min(data[:, 3]) - Delta
+    ymax = np.max(data[:, 3]) + Delta
     data = ET.Element('geometry')
     data.set('version', '0.8')
     data.set('caption', 'experiment')
@@ -264,7 +264,7 @@ def main():
         data = data[data[:, 1].argsort()]  # sort by frame
         data = extend_data(data, unit)
         geometry_file = File.parent.joinpath("geometry.xml")
-        write_geometry(data, unit, geometry_file)
+        write_geometry(data, unit_s, geometry_file)
         agents = np.unique(data[:, 0]).astype(int)
         for agent in agents:
             ped = data[data[:, 0] == agent]

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -275,11 +275,4 @@ def main():
 
 
 if __name__ == '__main__':
-    # import cProfile
-    # import pstats
-    # profiler = cProfile.Profile()
-    # profiler.enable()
     main()
-    # profiler.disable()
-    # stats = pstats.Stats(profiler).sort_stats('cumtime')
-    # print(stats.print_stats())

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -8,8 +8,7 @@ import numpy as np
 parser = argparse.ArgumentParser(
     description='''Modify trajectory-files to be
     visualized with jpsvis.
-    Trajectories are converted from cm to m.
-    Moreover, new columns are added (A, B, ANGLE, COLOR)
+    New columns are added (A, B, ANGLE, COLOR)
     A and B are constants. ANGLE is zero (so agents are circles)
     COLOR is calculated based on the speed assuming
     a maximal speed of 1.5m/s.
@@ -189,8 +188,8 @@ if __name__ == '__main__':
     except ValueError:
         sys.exit(f"can not convert input df {args.df} to int")
 
-    with open(File, encoding="utf8") as f:
-        header, fps, unit_s = extract_info(f)
+    with open(File, encoding="utf8") as finput:
+        header, fps, unit_s = extract_info(finput)
         unit = 100 if unit_s == "cm" else 1
         print(f"file: {File}")
         print(header)
@@ -198,6 +197,7 @@ if __name__ == '__main__':
         print(f"df: {df}")
         print(f"unit: {unit_s}")
         data = np.loadtxt(File)
+        
         rows, cols = data.shape
         H = 1.5 * np.ones((rows, 1)) * unit  # hight 150cm
         A = 0.3 * np.ones((rows, 1)) * unit  # circle with radius 30cm

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -207,25 +207,6 @@ def extend_data(data, _unit) -> np.array:
     return data
 
 
-def sort_data_framewise(data) -> np.array:
-    """sort trajectories framewise
-
-    :param data: input trajectories
-    :type data: np.array
-    :returns: np.array
-
-    """
-    print("--> sort trajectories frame-wise")
-    shape = data.shape
-    result = np.empty(shape[1])
-    frames = np.unique(data[:, 1]).astype(int)
-    for frame in frames:
-        data_fr = data_at_frame(data, frame)
-        result = np.vstack((result, data_fr))
-
-    return result
-
-
 def write_trajectories(result, header, File):
     """write the resulting trajecties in a file
 
@@ -278,17 +259,17 @@ def main():
                         sep=r"\s+",
                         dtype=np.float64,
                         comment="#").values
+        data = data[data[:, 1].argsort()]  # sort by frame
         data = extend_data(data, unit)
         geometry_file = File.parent.joinpath("geometry.xml")
         write_geometry(data, unit, geometry_file)
-        result = sort_data_framewise(data)
         agents = np.unique(data[:, 0]).astype(int)
         for agent in agents:
             ped = data[data[:, 0] == agent]
             speed = Speed(ped[:, 2:4], df, fps)
-            result[result[:, 0] == agent, -1] = speed/v0*255
+            data[data[:, 0] == agent, -1] = speed/v0*255
 
-        write_trajectories(result, header, File)
+        write_trajectories(data, header, File)
 
 
 if __name__ == '__main__':

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -171,15 +171,6 @@ def write_geometry(data, Unit, geo_file):
         f.write(b_xml)
 
 
-def data_at_frame(data, frame) -> np.array:
-    """Get data at frame
-    :param data: the trajectories from the file
-    :param frame: frame number
-    :returns: data at frame <frame>
-    """
-    return data[data[:, 1] == frame]
-
-
 def extend_data(data, _unit) -> np.array:
     """Append some new columns to the trajectories
     for visualisation purposes. These are:

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -160,28 +160,28 @@ def speed_angle(traj, df, fps):
     └────────►   *       *
                    *       *
     """
-    Size = traj.shape[0]
-    Speed = np.ones(Size)
-    Angle = np.zeros(Size)
-    if Size < df:
+    size = traj.shape[0]
+    speed = np.ones(size)
+    angle = np.zeros(size)
+    if size < df:
         log.warning(
             f"""The number of frames used to calculate the speed {df}
-            exceeds the total amount of frames ({Size}) in this trajectory.""")
-        return (Speed, Angle)
+            exceeds the total amount of frames ({size}) in this trajectory.""")
+        return (speed, angle)
 
-    Delta = traj[df:, :] - traj[:Size-df, :]
-    Delta_X = Delta[:, 0]
-    Delta_Y = Delta[:, 1]
-    Delta_square = np.square(Delta)
-    Delta_X_square = Delta_square[:, 0]
-    Delta_Y_square = Delta_square[:, 1]
-    Angle[: Size-df] = np.arctan2(Delta_Y,
-                                  Delta_X)*180/np.pi
-    s = np.sqrt(Delta_X_square + Delta_Y_square)
-    Speed[: Size-df] = s / df * fps
-    Speed[Size-df:] = Speed[Size-df-1]
-    Angle[Size-df:] = Angle[Size-df-1]
-    return (Speed, Angle)
+    delta = traj[df:, :] - traj[:size-df, :]
+    delta_x = delta[:, 0]
+    delta_y = delta[:, 1]
+    delta_square = np.square(delta)
+    delta_x_square = delta_square[:, 0]
+    delta_y_square = delta_square[:, 1]
+    angle[: size-df] = np.arctan2(delta_y,
+                                  delta_x)*180/np.pi
+    s = np.sqrt(delta_x_square + delta_y_square)
+    speed[: size-df] = s / df * fps
+    speed[size-df:] = speed[size-df-1]
+    angle[size-df:] = angle[size-df-1]
+    return (speed, angle)
 
 
 def write_geometry(data, Unit, geo_file):
@@ -338,7 +338,8 @@ def main():
                                 comment="#").values
 
             except Exception as err:
-                raise Exception(f"Trajectory is malformed: {err}") from err
+                log.error(f"Trajectory is malformed: {err}")
+                sys.exit()
 
             columns = data.shape[1]
             log.info(f"Got {columns} columns")

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -45,6 +45,13 @@ parser.add_argument("-d", "--df", default="10", dest='df',
                     type=check_positive_int,
                     help='''number of frames forward
                     to calculate the speed (default: 10)''')
+parser.add_argument("-a", default="0.2",
+                    type=float,
+                    help='''Semi-axis in moving direction (default: 0.2 m)''')
+parser.add_argument("-b", default="0.3",
+                    type=float,
+                    help='''Semi-axis in shoulder direction (default: 0.3 m)''')
+
 args = parser.parse_args()
 
 
@@ -264,15 +271,15 @@ def extend_data(data, _unit):
 
     """
     rows, cols = data.shape
-    H = 1.5 * np.ones((rows, 1)) * _unit  # height
-    A = 0.2 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
-    B = 0.3 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
-    ANGLE = np.zeros((rows, 1))  # angle in degree
-    COLOR = 100 * np.ones((rows, 1))  # will be set wrt. speed
+    h = 1.5 * np.ones((rows, 1)) * _unit  # height
+    a = args.a * np.ones((rows, 1)) * _unit  # semi-axis of ellipse in moving direction
+    b = args.b * np.ones((rows, 1)) * _unit  # semi-axis of ellipse in shoulder direction
+    angle = np.zeros((rows, 1))  # angle in degree
+    color = 100 * np.ones((rows, 1))  # will be set wrt. speed
     if cols == 4:  # some trajectories do not have Z
-        data = np.hstack((data, H, A, B, ANGLE, COLOR))
+        data = np.hstack((data, h, a, b, angle, color))
     else:
-        data = np.hstack((data, A, B, ANGLE, COLOR))
+        data = np.hstack((data, a, b, angle, color))
 
     return data
 
@@ -310,6 +317,8 @@ def write_debug_msg(traj_file, fps, df, unit_s):
     log.info(f"input : {traj_file} ({size_mb:,.2f} MB)")
     log.info(f"fps   : {fps}")
     log.info(f"df    : {df}")
+    log.info(f"a     : {args.a} m")
+    log.info(f"b     : {args.b} m")
     log.info(f"unit  : {unit_s}")
 
 

--- a/scripts/petrack2jpsvis.py
+++ b/scripts/petrack2jpsvis.py
@@ -265,8 +265,8 @@ def extend_data(data, _unit):
     """
     rows, cols = data.shape
     H = 1.5 * np.ones((rows, 1)) * _unit  # height
-    A = 0.3 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
-    B = 0.2 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
+    A = 0.2 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
+    B = 0.3 * np.ones((rows, 1)) * _unit  # semi-axis of ellipse
     ANGLE = np.zeros((rows, 1))  # angle in degree
     COLOR = 100 * np.ones((rows, 1))  # will be set wrt. speed
     if cols == 4:  # some trajectories do not have Z
@@ -322,10 +322,15 @@ def main():
             unit = 100 if unit_s == "cm" else 1
             v0 = 1.5 * unit  # max. speed (assumed) [unit/s]
             write_debug_msg(input_file, fps, df, unit_s)
-            data = read_csv(input_file,
-                            sep=r"\s+",
-                            dtype=np.float64,
-                            comment="#").values
+            try:
+                data = read_csv(input_file,
+                                sep=r"\s+",
+                                dtype=np.float64,
+                                comment="#").values
+
+            except Exception as err:
+                raise Exception(f"Trajectory is malformed: {err}") from err
+
             columns = data.shape[1]
             log.info(f"Got {columns} columns")
             nframes = np.unique(data[:, 1]).size


### PR DESCRIPTION
Address issue #120. 

Convert [Petrack-files](https://ped.fz-juelich.de/db) to a JuPedSim-compatible [format](https://www.jupedsim.org/jpscore_trajectory.html#default-output).

- [x] some petrack files do not have a header
- [x] extract correct unit from trajectory. Some files are in cm and some are in m.
- [x] Some petrack files have only 4 columns (without header) 

Example: Bottleneck and social groups

```
 python ~/workspace/jupedsim/jpsvis/scripts/petrack2jpsvis.py -f 00_08.txt --df  10
```

<img width="505" alt="Screen Shot 2022-01-08 at 12 16 34" src="https://user-images.githubusercontent.com/5772973/148642070-67a69bce-637c-4e80-8f75-babce2f9a228.png">


![result](https://user-images.githubusercontent.com/5772973/148660157-a64e67ef-8a2c-44ad-9115-e094bc4f3068.gif)

