### PR TITLE
Fix windows installer creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,6 @@ list(APPEND COMMON_COMPILE_OPTIONS
     $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
 )
 
-
-
 message( STATUS "System ........................................ ${CMAKE_SYSTEM_NAME} (${CMAKE_SYSTEM_VERSION}, ${CMAKE_SYSTEM_PROCESSOR})" )
 message( STATUS "Generating  ................................... ${PROJECT_NAME} (${PROJECT_VERSION})")
 

--- a/cmake/install_helper.cmake
+++ b/cmake/install_helper.cmake
@@ -119,6 +119,9 @@ macro(write_package_information_win)
   set(CPACK_NSIS_PACKAGE_NAME "JPSvis")
   set(CPACK_NSIS_INSTALLED_ICON_NAME "${CMAKE_SOURCE_DIR}/forms/jpsvis.ico")
   set(CPACK_NSIS_URL_INFO_ABOUT ${CPACK_NSIS_HELP_LINK})
+  set(CPACK_NSIS_MENU_LINKS
+    "bin/jpsvis.exe"
+    "jpsvis")
   set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
   set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS
 	  "CreateShortCut '$DESKTOP\\\\JPSvis.lnk' '$INSTDIR\\\\bin\\\\jpsvis.exe'"
@@ -132,39 +135,81 @@ macro(write_package_content_win)
     include(InstallRequiredSystemLibraries)
     include(GNUInstallDirs)
     install(TARGETS jpsvis)
-
-    install(CODE [[
-        file(GET_RUNTIME_DEPENDENCIES
-            RESOLVED_DEPENDENCIES_VAR RES
-            UNRESOLVED_DEPENDENCIES_VAR UNRES
-            CONFLICTING_DEPENDENCIES_PREFIX CONFLICTING_DEPENDENCIES
-            EXECUTABLES $<TARGET_FILE:jpsvis>
-            LIBRARIES $<TARGET_FILE:vis>
-            PRE_EXCLUDE_REGEXES api-ms-win-.* ext-ms-.* kernel32.dll qt5.*.dll
-            POST_EXCLUDE_REGEXES .*system32.*.dll qt5.*.dll
-            POST_INCLUDE_REGEXES .*system32.*opengl.*dll
-        )
-
-        foreach(DEP ${RES})
-            file(INSTALL
-              DESTINATION "${CMAKE_INSTALL_PREFIX}/bin"
-              TYPE SHARED_LIBRARY
-              FOLLOW_SYMLINK_CHAIN
-              FILES "${DEP}"
-            )
-        endforeach()
-        list(LENGTH _u_deps _u_length)
-        if("${_u_length}" GREATER 0)
-        message(WARNING "Unresolved dependencies detected!")
-        endif()
-    ]])
-
-    get_target_property(mocExe Qt5::moc IMPORTED_LOCATION)
-    get_filename_component(qtBinDir "${mocExe}" DIRECTORY)
-    find_program(DEPLOYQT_EXECUTABLE windeployqt PATHS "${qtBinDir}" NO_DEFAULT_PATH)
-    set(DEPLOY_OPTIONS [["${CMAKE_INSTALL_PREFIX}/bin/jpsvis.exe" -verbose=0]])
-    configure_file(${CMAKE_SOURCE_DIR}/cmake/deployapp.cmake.in deployapp.cmake @ONLY)
-    install(SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/deployapp.cmake)
+    install(FILES
+        $<TARGET_FILE_DIR:jpsvis>/brotlicommon.dll
+        $<TARGET_FILE_DIR:jpsvis>/brotlidec.dll
+        $<TARGET_FILE_DIR:jpsvis>/bz2.dll
+        $<TARGET_FILE_DIR:jpsvis>/freetype.dll
+        $<TARGET_FILE_DIR:jpsvis>/glew32.dll
+        $<TARGET_FILE_DIR:jpsvis>/harfbuzz.dll
+        $<TARGET_FILE_DIR:jpsvis>/icuuc69.dll
+        $<TARGET_FILE_DIR:jpsvis>/jpeg62.dll
+        $<TARGET_FILE_DIR:jpsvis>/libexpat.dll
+        $<TARGET_FILE_DIR:jpsvis>/libpng16.dll
+        $<TARGET_FILE_DIR:jpsvis>/lz4.dll
+        $<TARGET_FILE_DIR:jpsvis>/lzma.dll
+        $<TARGET_FILE_DIR:jpsvis>/pcre2-16.dll
+        $<TARGET_FILE_DIR:jpsvis>/pugixml.dll
+        $<TARGET_FILE_DIR:jpsvis>/Qt5Core.dll
+        $<TARGET_FILE_DIR:jpsvis>/Qt5Gui.dll
+        $<TARGET_FILE_DIR:jpsvis>/Qt5Widgets.dll
+        $<TARGET_FILE_DIR:jpsvis>/Qt5Xml.dll
+        $<TARGET_FILE_DIR:jpsvis>/tiff.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonColor-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonComputationalGeometry-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonDataModel-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonExecutionModel-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonMath-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonMisc-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonSystem-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkCommonTransforms-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkDICOMParser-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersExtraction-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersGeneral-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersGeometry-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersHybrid-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersModeling-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersSources-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersStatistics-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkFiltersTexture-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkGUISupportQt-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingColor-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingFourier-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingGeneral-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingHybrid-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingSources-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkImagingSources-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkInteractionStyle-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkInteractionWidgets-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkIOCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkIOImage-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkIOLegacy-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkIOXML-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkIOXMLParser-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkloguru-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkmetaio-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkParallelCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkParallelDIY-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingAnnotation-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingCore-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingFreeType-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingLabel-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingOpenGL2-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtkRenderingUI-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/vtksys-9.0.dll
+        $<TARGET_FILE_DIR:jpsvis>/zlib1.dll
+        $<TARGET_FILE_DIR:jpsvis>/zstd.dll
+        $<TARGET_FILE_DIR:jpsvis>/icuin69.dll
+        $<TARGET_FILE_DIR:jpsvis>/icudt69.dll
+        TYPE BIN
+    )
+    install(DIRECTORY
+        $<TARGET_FILE_DIR:jpsvis>/plugins
+        TYPE BIN
+    )
 endmacro()
 
 ################################################################################


### PR DESCRIPTION
The created installer can be found here:  https://fz-juelich.sciebo.de/s/AO2bJPQuVjyaO6X

Note: `file(GET_RUNTIME_DEPENDENCIES` is only available with CMake 3.21+ should the `CMakeLists.txt` be edited accordingly? Then we need to update the linux CI ...