### PR TITLE
Upload MacOS installer to sciebo

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build . --config $BUILD_TYPE --parallel
 
       - name: Cpack
         working-directory: ${{github.workspace}}/build
@@ -57,9 +57,31 @@ jobs:
         run: |
           source /Users/runner/.bash_profile
           cpack -C $BUILD_TYPE -G DragNDrop --verbose
+          installer=$(echo jpsvis-installer-*.dmg)
+          mv $(echo jpsvis-installer-*.dmg) "${installer%.dmg}-${{ matrix.os }}.dmg"
 
       - name: 'Upload installer'
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}-installer
           path: ${{github.workspace}}/build/jpsvis-installer-*.dmg
+
+      - name: 'Upload installer to sciebo (nightly)'
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        env:
+          sciebo_url_nightly: ${{ secrets.SCIEBO_INSTALLER_PATH_NIGHTLY}}
+        #        if: github.ref == 'refs/heads/master'
+        run: |
+          macosInst=$(echo jpsvis-installer-*.dmg)
+          curl -k -T $macosInst -u "$sciebo_url_nightly:" https://fz-juelich.sciebo.de/public.php/webdav/$macosInst --fail-with-body
+
+      - name: 'Upload installer to sciebo (stable)'
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        env:
+          sciebo_url_stable: ${{ secrets.SCIEBO_INSTALLER_PATH_STABLE}}
+#        if: ${{ github.event_name == 'create' && github.event.ref_type == 'tag' }}
+        run: |
+          macosInst=$(echo jpsvis-installer-*.dmg)
+          curl -k -T $macosInst -u "$sciebo_url_stable:" https://fz-juelich.sciebo.de/public.php/webdav/$macosInst --fail-with-body


### PR DESCRIPTION
Uploads the installer (all version created in the CI) to sciebo

- [ ] Remove place holder to upload only on push to master
- [ ] Remove place holder to upload only when tag is created